### PR TITLE
make copy text visible

### DIFF
--- a/index.css
+++ b/index.css
@@ -161,7 +161,6 @@ code:hover {
 }
 
 .copy {
-  opacity: 0;
   color: #159957;
   font-size: 15px;
   -webkit-transition: opacity 0.35s ease-in-out;


### PR DESCRIPTION
- removed opacity from .copy class - so that text is visible by default
- close #1